### PR TITLE
Active people managers feature

### DIFF
--- a/spec/features/event_external_application_spec.rb
+++ b/spec/features/event_external_application_spec.rb
@@ -36,6 +36,9 @@ describe :event_external_application do
       )
     end.to change { Person.count }.by(1)
 
+    click_link("Anmelden")
+    find_all(".bottom .btn-group").first.click_button "Weiter"
+
     fill_in("Bemerkungen", with: "Wichtige Bemerkungen über meine Teilnahme")
 
     expect do


### PR DESCRIPTION
Mit dem Elternzugang hat sich der Anmelde-Workflow etwas geändert, weswegen der Feature Spec angepasst werden musste.